### PR TITLE
Rename to json_nlohmann

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.1)
 ## PROJECT
 ## name and version
 ##
-project(nlohmann_json VERSION 3.9.1 LANGUAGES CXX)
+project(json_nlohmann VERSION 3.9.1 LANGUAGES CXX)
 
 ##
 ## INCLUDE
@@ -59,11 +59,6 @@ find_package(catkin REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS single_include
-)
-
-include_directories(
-  single_include
-  ${catkin_INCLUDE_DIRS}
 )
 
 ##

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>nlohmann_json</name>
+  <name>json_nlohmann</name>
   <version>3.9.1</version>
   <description>
      JSON for Modern C++


### PR DESCRIPTION
This:
* removes the unused ìnclude_directories`
* rename to `json_nlohmann` to better fit expectations (searching for json as per the repo name)
